### PR TITLE
Add secure backend authentication with hashed passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+backend/*.sqlite*

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,70 @@
+import initSqlJs from 'sql.js'
+import fs from 'node:fs'
+import path from 'node:path'
+import { Buffer } from 'node:buffer'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const DATABASE_FILE = path.join(__dirname, 'data.sqlite')
+
+const sql = await initSqlJs({
+  locateFile: (file) => path.resolve(__dirname, '../node_modules/sql.js/dist', file)
+})
+
+const database = fs.existsSync(DATABASE_FILE)
+  ? new sql.Database(fs.readFileSync(DATABASE_FILE))
+  : new sql.Database()
+
+database.run(`
+  CREATE TABLE IF NOT EXISTS admins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+`)
+
+database.run(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+`)
+
+persistDatabase()
+
+function persistDatabase() {
+  const data = database.export()
+  fs.writeFileSync(DATABASE_FILE, Buffer.from(data))
+}
+
+export function run(query, params = []) {
+  database.run(query, params)
+  persistDatabase()
+}
+
+export function insert(query, params = []) {
+  database.run(query, params)
+  const [result] = database.exec('SELECT last_insert_rowid() as id;')
+  persistDatabase()
+  const insertedId = result?.values?.[0]?.[0]
+  return typeof insertedId === 'number' ? insertedId : null
+}
+
+export function get(query, params = []) {
+  const statement = database.prepare(query)
+  try {
+    statement.bind(params)
+    if (statement.step()) {
+      return statement.getAsObject()
+    }
+    return null
+  } finally {
+    statement.free()
+  }
+}

--- a/backend/repositories/adminRepository.js
+++ b/backend/repositories/adminRepository.js
@@ -1,0 +1,15 @@
+import { get, insert } from '../db.js'
+
+export function insertAdmin({ username, name, passwordHash }) {
+  return insert(
+    `INSERT INTO admins (username, name, password_hash) VALUES (?, ?, ?);`,
+    [username, name, passwordHash]
+  )
+}
+
+export function findAdminByUsername(username) {
+  return get(
+    `SELECT id, username, name, password_hash, created_at FROM admins WHERE username = ?;`,
+    [username]
+  )
+}

--- a/backend/repositories/userRepository.js
+++ b/backend/repositories/userRepository.js
@@ -1,0 +1,15 @@
+import { get, insert } from '../db.js'
+
+export function insertUser({ username, name, passwordHash }) {
+  return insert(
+    `INSERT INTO users (username, name, password_hash) VALUES (?, ?, ?);`,
+    [username, name, passwordHash]
+  )
+}
+
+export function findUserByUsername(username) {
+  return get(
+    `SELECT id, username, name, password_hash, created_at FROM users WHERE username = ?;`,
+    [username]
+  )
+}

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -1,0 +1,16 @@
+import process from 'node:process'
+import { ensureAdmin } from './services/adminService.js'
+
+const DEFAULT_ADMIN = {
+  username: process.env.DEFAULT_ADMIN_USERNAME ?? 'admin',
+  password: process.env.DEFAULT_ADMIN_PASSWORD ?? 'admin123456',
+  name: process.env.DEFAULT_ADMIN_NAME ?? 'Administrador Padrão'
+}
+
+try {
+  const admin = ensureAdmin(DEFAULT_ADMIN)
+  console.log(`Administrador padrão disponível: ${admin.username}`)
+} catch (error) {
+  console.error('Não foi possível criar o administrador padrão.', error)
+  process.exitCode = 1
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,72 @@
+import express from 'express'
+import cors from 'cors'
+import process from 'node:process'
+import { authenticate } from './services/authService.js'
+import { createAdmin } from './services/adminService.js'
+import { createUser } from './services/userService.js'
+
+const app = express()
+const PORT = process.env.PORT || 4000
+
+app.use(cors())
+app.use(express.json())
+
+app.post('/api/admins', (req, res) => {
+  const { username, password, name } = req.body ?? {}
+
+  if (!username || !password || !name) {
+    return res.status(400).json({ message: 'username, password e name são obrigatórios.' })
+  }
+
+  try {
+    const admin = createAdmin({ username, password, name })
+    return res.status(201).json({ admin })
+  } catch (error) {
+    if (typeof error?.message === 'string' && error.message.includes('SQLITE_CONSTRAINT')) {
+      return res.status(409).json({ message: 'Nome de usuário já está em uso.' })
+    }
+
+    console.error('Erro ao criar admin:', error)
+    return res.status(500).json({ message: 'Não foi possível criar o admin.' })
+  }
+})
+
+app.post('/api/users', (req, res) => {
+  const { username, password, name } = req.body ?? {}
+
+  if (!username || !password || !name) {
+    return res.status(400).json({ message: 'username, password e name são obrigatórios.' })
+  }
+
+  try {
+    const user = createUser({ username, password, name })
+    return res.status(201).json({ user })
+  } catch (error) {
+    if (typeof error?.message === 'string' && error.message.includes('SQLITE_CONSTRAINT')) {
+      return res.status(409).json({ message: 'Nome de usuário já está em uso.' })
+    }
+
+    console.error('Erro ao criar usuário:', error)
+    return res.status(500).json({ message: 'Não foi possível criar o usuário.' })
+  }
+})
+
+app.post('/api/login', (req, res) => {
+  const { username, password, role } = req.body ?? {}
+
+  if (!username || !password) {
+    return res.status(400).json({ message: 'username e password são obrigatórios.' })
+  }
+
+  const result = authenticate({ username, password, role })
+
+  if (!result) {
+    return res.status(401).json({ message: 'Credenciais inválidas.' })
+  }
+
+  return res.json({ account: result })
+})
+
+app.listen(PORT, () => {
+  console.log(`Servidor ouvindo na porta ${PORT}`)
+})

--- a/backend/services/adminService.js
+++ b/backend/services/adminService.js
@@ -1,0 +1,28 @@
+import bcrypt from 'bcryptjs'
+import { findAdminByUsername, insertAdmin } from '../repositories/adminRepository.js'
+
+const SALT_ROUNDS = 12
+
+function sanitizeAdminRow(row) {
+  if (!row) return null
+  const { id, username, name, created_at: createdAt } = row
+  return { id, username, name, createdAt }
+}
+
+export function createAdmin({ username, password, name }) {
+  const passwordHash = bcrypt.hashSync(password, SALT_ROUNDS)
+  insertAdmin({ username, name, passwordHash })
+  return sanitizeAdminRow(findAdminByUsername(username))
+}
+
+export function ensureAdmin({ username, password, name }) {
+  const existing = findAdminByUsername(username)
+  if (existing) {
+    return sanitizeAdminRow(existing)
+  }
+  return createAdmin({ username, password, name })
+}
+
+export function findAdminForAuthentication(username) {
+  return findAdminByUsername(username)
+}

--- a/backend/services/authService.js
+++ b/backend/services/authService.js
@@ -1,0 +1,43 @@
+import bcrypt from 'bcryptjs'
+import { findAdminForAuthentication } from './adminService.js'
+import { findUserForAuthentication } from './userService.js'
+
+function sanitizeAuthenticatedAccount(row, role) {
+  if (!row) return null
+  const { id, username, name, created_at: createdAt } = row
+  return { id, username, name, createdAt, role }
+}
+
+function verifyPassword(row, password) {
+  if (!row) return null
+  const isValid = bcrypt.compareSync(password, row.password_hash)
+  return isValid ? row : null
+}
+
+function authenticateAdmin(username, password) {
+  const adminRow = findAdminForAuthentication(username)
+  const validAdmin = verifyPassword(adminRow, password)
+  return sanitizeAuthenticatedAccount(validAdmin, 'admin')
+}
+
+function authenticateUser(username, password) {
+  const userRow = findUserForAuthentication(username)
+  const validUser = verifyPassword(userRow, password)
+  return sanitizeAuthenticatedAccount(validUser, 'user')
+}
+
+export function authenticate({ username, password, role }) {
+  if (!username || !password) {
+    return null
+  }
+
+  if (role === 'admin') {
+    return authenticateAdmin(username, password)
+  }
+
+  if (role === 'user') {
+    return authenticateUser(username, password)
+  }
+
+  return authenticateAdmin(username, password) ?? authenticateUser(username, password)
+}

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -1,0 +1,20 @@
+import bcrypt from 'bcryptjs'
+import { findUserByUsername, insertUser } from '../repositories/userRepository.js'
+
+const SALT_ROUNDS = 12
+
+function sanitizeUserRow(row) {
+  if (!row) return null
+  const { id, username, name, created_at: createdAt } = row
+  return { id, username, name, createdAt }
+}
+
+export function createUser({ username, password, name }) {
+  const passwordHash = bcrypt.hashSync(password, SALT_ROUNDS)
+  insertUser({ username, name, passwordHash })
+  return sanitizeUserRow(findUserByUsername(username))
+}
+
+export function findUserForAuthentication(username) {
+  return findUserByUsername(username)
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node backend/server.js",
+    "seed": "node backend/seed.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -38,11 +40,14 @@
     "@radix-ui/react-toggle-group": "^1.1.9",
     "@radix-ui/react-tooltip": "^1.2.6",
     "@tailwindcss/vite": "^4.1.7",
+    "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
+    "express": "^5.1.0",
     "framer-motion": "^12.15.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
@@ -55,6 +60,7 @@
     "react-router-dom": "^7.6.1",
     "recharts": "^2.15.3",
     "sonner": "^2.0.3",
+    "sql.js": "^1.11.0",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",
     "vaul": "^1.1.2",
@@ -72,5 +78,13 @@
     "tw-animate-css": "^1.2.9",
     "vite": "^6.3.5"
   },
-  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
+  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "esbuild"
+    ],
+    "onlyBuiltDependencies": [
+      "@tailwindcss/oxide"
+    ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.7
         version: 4.1.7(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -101,12 +104,18 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
       framer-motion:
         specifier: ^12.15.0
         version: 12.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -143,6 +152,9 @@ importers:
       sonner:
         specifier: ^2.0.3
         version: 2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      sql.js:
+        specifier: ^1.11.0
+        version: 1.13.0
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1176,67 +1188,56 @@ packages:
     resolution: {integrity: sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.2':
     resolution: {integrity: sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.2':
     resolution: {integrity: sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.2':
     resolution: {integrity: sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.2':
     resolution: {integrity: sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.2':
     resolution: {integrity: sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.2':
     resolution: {integrity: sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.2':
     resolution: {integrity: sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.2':
     resolution: {integrity: sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.2':
     resolution: {integrity: sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.2':
     resolution: {integrity: sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.2':
     resolution: {integrity: sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==}
@@ -1294,28 +1295,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.7':
     resolution: {integrity: sha512-PjGuNNmJeKHnP58M7XyjJyla8LPo+RmwHQpBI+W/OxqrwojyuCQ+GUtygu7jUqTEexejZHr/z3nBc/gTiXBj4A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.7':
     resolution: {integrity: sha512-HMs+Va+ZR3gC3mLZE00gXxtBo3JoSQxtu9lobbZd+DmfkIxR54NO7Z+UQNPsa0P/ITn1TevtFxXTpsRU7qEvWg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.7':
     resolution: {integrity: sha512-MHZ6jyNlutdHH8rd+YTdr3QbXrHXqwIhHw9e7yXEBcQdluGwhpQY2Eku8UZK6ReLaWtQ4gijIv5QoM5eE+qlsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.7':
     resolution: {integrity: sha512-ANaSKt74ZRzE2TvJmUcbFQ8zS201cIPxUDm5qez5rLEwWkie2SkGtA4P+GPTj+u8N6JbPrC8MtY8RmJA35Oo+A==}
@@ -1439,6 +1436,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -1987,28 +1987,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2385,6 +2381,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sql.js@1.13.0:
+    resolution: {integrity: sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==}
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -3752,6 +3751,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bcryptjs@2.4.3: {}
+
   body-parser@2.2.0:
     dependencies:
       bytes: 3.1.2
@@ -4691,6 +4692,8 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
+
+  sql.js@1.13.0: {}
 
   statuses@2.0.1: {}
 

--- a/src/App-complex.jsx
+++ b/src/App-complex.jsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/ui/input.jsx'
 import { Textarea } from '@/components/ui/textarea.jsx'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.jsx'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog.jsx'
 import { Label } from '@/components/ui/label.jsx'
 import { Plus, Search, Filter, MessageSquare, Bug, Zap, Clock, CheckCircle, AlertCircle, User, Bell } from 'lucide-react'
 import DemandDetails from './components/DemandDetails.jsx'
@@ -18,7 +17,6 @@ function App() {
   const [searchTerm, setSearchTerm] = useState('')
   const [filterStatus, setFilterStatus] = useState('todos')
   const [filterType, setFilterType] = useState('todos')
-  const [isNewDemandOpen, setIsNewDemandOpen] = useState(false)
   const [selectedDemand, setSelectedDemand] = useState(null)
   const [showNotifications, setShowNotifications] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false) // Toggle para simular modo admin
@@ -128,7 +126,6 @@ function App() {
       ultimaAtualizacao: new Date().toISOString().split('T')[0]
     }
     setDemandas([...demandas, novaDemanda])
-    setIsNewDemandOpen(false)
     event.target.reset()
     setActiveTab('minhas-demandas') // Redirecionar para a lista após criar
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': resolve(dirname(fileURLToPath(import.meta.url)), './src')
     },
   },
 })


### PR DESCRIPTION
## Summary
- add an Express + sql.js backend that persists admin and user credentials with bcrypt hashes and exposes register/login endpoints
- seed default admin credentials directly in the database to replace front-end constants and simplify setup
- wire new scripts/dependencies and clean up existing config/state for the ESM toolchain

## Testing
- pnpm seed
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c898f42f288325bbc0d030055de1ac